### PR TITLE
Refactor main entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -164,7 +164,7 @@ def create_dataset():
         logging.error(f"Error creating dataset: {e}")
         raise
 
-if __name__ == "__main__":
+
 def main():
     try:
         logging.info("Starting training pipeline...")
@@ -189,6 +189,7 @@ def main():
     except Exception as e:
         logging.error(f"Pipeline failed: {e}")
         raise
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- remove stray `if __name__ == '__main__':` before `main` definition
- define `main()` at module scope and add proper `__main__` guard

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68977ff982708330bc6f6749bb654986